### PR TITLE
[circle-opselector] Update select_nodes feature

### DIFF
--- a/compiler/circle-opselector/driver/Driver.cpp
+++ b/compiler/circle-opselector/driver/Driver.cpp
@@ -44,7 +44,7 @@ bool check_input(std::string str)
   if (str[0] == '-' || str[str.size()-1] == '-')
   {
     std::cout << "Invalid input." << std::endl;
-    exit(0);
+    exit(1);
   }
 
   for (char c : str)
@@ -54,14 +54,14 @@ bool check_input(std::string str)
     else if (check_hyphen) // when user enter '-' more than 2.
     {
       std::cout << "Too many '-' in str." << std::endl;
-      exit(0);
+      exit(1);
     }
     else if (c == '-')
       check_hyphen = true;
     else // when user enter not allowed character, print alert msg.
     {
       std::cout << "To select operator by id, please use these args: [0-9], '-', ','" << std::endl;
-      exit(0);
+      exit(1);
     }
   }
   return true;
@@ -97,17 +97,17 @@ void split_id_input(const std::string &str, std::vector<int> &by_id)
       catch (std::invalid_argument &error)
       {
         std::cerr << "ERROR: [circle-opselector] Invalid argument.(stoi)" << std::endl;
-        exit(0);
+        exit(1);
       }
       catch (std::out_of_range)
       {
         std::cout << "ERROR: [circle-opselector] Argument is out of range(stoi)\n";
-        exit(0);
+        exit(1);
       }
       catch (...)
       {
         std::cout << "ERROR: [circle-opselector] Unknown error(stoi)\n";
-        exit(0);
+        exit(1);
       }
     }
   }

--- a/compiler/circle-opselector/driver/Driver.cpp
+++ b/compiler/circle-opselector/driver/Driver.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "OpSelector.h"
-// TODO Add new pass headers
 
 #include <foder/FileLoader.h>
 
@@ -41,7 +40,7 @@ bool check_input(std::string str)
 {
   bool check_hyphen = false;
 
-  if (str[0] == '-' || str[str.size()-1] == '-')
+  if (str[0] == '-' || str[str.size() - 1] == '-')
   {
     std::cout << "Invalid input." << std::endl;
     exit(1);
@@ -123,78 +122,6 @@ void split_name_input(const std::string &str, std::vector<std::string> &by_name)
     by_name.push_back(str_buf);
 }
 
-void getOplist(std::string op, std::vector<int> &oplist)
-{
-  char op_buf[1000];
-  strcpy(op_buf, op.c_str());
-  char *op_next = op_buf;
-
-  // tokenize by ,
-  char *tok_comma = strtok_r(op_buf, ",", &op_next);
-  while (tok_comma != nullptr)
-  {
-    char buf[100];
-    strcpy(buf, tok_comma);
-    char *buf_next = buf;
-
-    if (isdigit(tok_comma[0]))
-    {
-      int start, end;
-      // "n-m" : select n~m
-      char *tok_hypen = strtok_r(buf, "-", &buf_next);
-      if (tok_hypen && isdigit(tok_hypen[0]))
-      {
-        start = atoi(tok_hypen);
-      }
-
-      tok_hypen = strtok_r(nullptr, "-", &buf_next);
-      // "n-m" : select n~m
-      if (tok_hypen && isdigit(tok_hypen[0]))
-      {
-        end = atoi(tok_hypen);
-        for (int i = start; i <= end; i++)
-          oplist.push_back(i);
-      }
-      // "n-:" : select n~
-      else if (tok_hypen && tok_hypen[0] == ':')
-      {
-        oplist.push_back(start);
-        oplist.push_back(-1);
-      }
-      // "n" : select n
-      else
-      {
-        oplist.push_back(start);
-      }
-    }
-    // ":-n" : select 0~n
-    else if (tok_comma[0] == ':')
-    {
-      char *tok_hypen = strtok_r(buf, "-", &buf_next);
-      tok_hypen = strtok_r(nullptr, "-", &buf_next);
-      if (tok_hypen && isdigit(tok_hypen[0]))
-      {
-        int end = atoi(tok_hypen);
-        for (int i = 0; i <= end; i++)
-          oplist.push_back(i);
-      }
-    }
-    else
-    {
-      std::cout << "Error: Cannot get operators" << std::endl;
-    }
-
-    tok_comma = strtok_r(nullptr, ",", &op_next);
-  }
-
-  sort(oplist.begin(), oplist.end());
-
-  std::cout << "result: ";
-  for (int i = 0; i < oplist.size(); i++)
-    std::cout << oplist[i] << " ";
-  std::cout << std::endl;
-}
-
 int entry(int argc, char **argv)
 {
   // TODO Add new option names!
@@ -249,6 +176,7 @@ int entry(int argc, char **argv)
 
   std::vector<int> by_id;
   std::vector<std::string> by_name;
+
   std::string op;
   std::vector<int> oplist;
   int select_mode = -1;
@@ -265,15 +193,9 @@ int entry(int argc, char **argv)
   }
   if (arser["--select"])
   {
-    op = arser.get<std::string>("--select");
-    select_mode = 0;
-    getOplist(op, oplist);
   }
   if (arser["--deselect"])
   {
-    op = arser.get<std::string>("--deselect");
-    select_mode = 1;
-    getOplist(op, oplist);
   }
 
   // option parsing test code.
@@ -306,25 +228,32 @@ int entry(int argc, char **argv)
   luci::Importer importer;
   auto module = importer.importModule(circle_model);
 
-  // TODO Add function
+  // Select and Import from user input.
+  opselector::OpSelector *selector = new opselector::OpSelector(circle_model);
+  std::map<uint32_t, std::string> _source_table = module.get()->source_table();
+  std::map<uint32_t, std::string> id_name_selected_nodes;
+
+  // put selected nodes into map.
   if (by_id.size())
   {
-    opselector::OpSelector *selector = new opselector::OpSelector();
-    std::map<uint32_t, std::string> _source_table = module.get()->source_table();
-    std::map<uint32_t, std::string> id_name_selected_nodes;
-
-    for(auto id : by_id)
+    for (auto id : by_id)
     {
-      for(auto iter=_source_table.begin();iter!=_source_table.end();iter++)
-        if(iter->first == id)
+      for (auto iter = _source_table.begin(); iter != _source_table.end(); iter++)
+        if (iter->first == id)
           id_name_selected_nodes[iter->first] = iter->second; // {id : name} mapping
     }
-
-    module = selector->select_nodes(circle_model, id_name_selected_nodes);
   }
-  if(by_name.size())
+  if (by_name.size())
   {
+    for (auto id : by_name)
+    {
+      for (auto iter = _source_table.begin(); iter != _source_table.end(); iter++)
+        if (iter->second.find(id) != std::string::npos)
+          id_name_selected_nodes[iter->first] = iter->second; // {id : name} mapping
+    }
   }
+  // Import selected nodes.
+  module = selector->select_nodes(id_name_selected_nodes);
 
   // Export to output Circle file
   luci::CircleExporter exporter;

--- a/compiler/circle-opselector/pass/OpSelector.cpp
+++ b/compiler/circle-opselector/pass/OpSelector.cpp
@@ -213,7 +213,7 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
   }
 }
 
-std::unique_ptr<luci::Module> select_nodes(const circle::Model *circle_model,
+std::unique_ptr<luci::Module> OpSelector::select_nodes(const circle::Model *circle_model,
                                            std::map<uint32_t, std::string> &id_name_selected_nodes)
 {
   auto module = luci::make_module();

--- a/compiler/circle-opselector/pass/OpSelector.cpp
+++ b/compiler/circle-opselector/pass/OpSelector.cpp
@@ -41,7 +41,6 @@ namespace opselector
 void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &reader,
                    loco::Graph *graph)
 {
-
   auto nodefinder = std::make_unique<luci::IndexNodeFinder>();
   auto tensoroutputs = std::make_unique<luci::IndexTensorOutputs>();
 
@@ -51,7 +50,6 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
   const auto &tensors = reader.tensors();
   auto tensors_ptr = reader.tensors_ptr();
   assert(tensors_ptr != nullptr);
-  auto circle_metadata = std::make_unique<luci::CircleImportMetadata>(reader);
 
   // build a cache to identify if a tensor is output of an operator
   // if this is set, we should not create a CircleConst for this tensor
@@ -126,7 +124,6 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
   // Note that operators in model are stored in execution order. This means that when importing
   // an operator, its input operators have already been imported. We exploit this fact to set up
   // node's inputs right after creating the node.
-  auto origin_table = circle_metadata->origin_table();
   for (uint32_t i = 0; i < operators.size(); ++i)
   {
     const circle::OperatorT &op = *operators[i];
@@ -142,10 +139,8 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
 
       auto built_op = builder->build(op, &gb_context);
       set_node_id(built_op, i);
-      if (origin_table.find(i) != origin_table.end())
-        add_origin(built_op, origin_table.at(i));
-      else
-        add_origin(built_op, luci::single_origin(i, built_op->name()));
+
+      add_origin(built_op, luci::single_origin(i, built_op->name()));
     }
     else
     {
@@ -178,7 +173,6 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
       else
         output_dummy->shape_status(luci::ShapeStatus::VALID);
     }
-
 
     // set the graph output name and node object
     auto graph_output = graph->outputs()->create();
@@ -213,57 +207,113 @@ void convert_graph(const luci::GraphBuilderSource &source, luci::CircleReader &r
   }
 }
 
-std::unique_ptr<luci::Module> OpSelector::select_nodes(const circle::Model *circle_model,
-                                           std::map<uint32_t, std::string> &id_name_selected_nodes)
+std::unique_ptr<luci::Module>
+OpSelector::select_nodes(std::map<uint32_t, std::string> &id_name_selected_nodes)
 {
   auto module = luci::make_module();
 
   const luci::GraphBuilderSource *source_ptr = &luci::GraphBuilderRegistry::get();
-  luci::CircleReader reader;
-
-  assert(reader.parse(circle_model));
 
   for (uint32_t g = 0; g < 1; ++g)
   {
-    std::unique_ptr<loco::Graph> graph = loco::make_graph();
-    std::vector<const circle::OperatorT*> selected_operators;
+    std::unique_ptr<loco::Graph> graph = loco::make_graph(); // create new empty graph
 
-    reader.select_subgraph(g);
-    
-    graph->name(reader.name());
+    std::vector<const circle::OperatorT *> selected_operators; // nodes that user want to select
+    std::vector<const circle::OperatorT *>
+      input_nodes; // the nodes that one's input is not connected with other node's output
+    std::vector<const circle::OperatorT *>
+      output_nodes; // the nodes that one's output is not connected with other node's input
 
-    std::cout<<"Subgraph Name: "<< reader.name() << std::endl;
+    _reader.select_subgraph(g); // select subgraph. usually, 0 is main
 
-    const auto &opers = reader.operators(); // 오퍼레이터는 우리가 netron을 통해 확인할 수 있는 그 노드들의 tensor()상의 인덱스를 저장하고 있음
-    const auto &tense = reader.tensors();
-    auto tensors_ptr = reader.tensors_ptr();
+    graph->name(_reader.name()); // set name of graph (if it has one graph, name is empty.)
+
+    const auto &operators = _reader.operators(); // operator is the nodes that we can see in netron.
+                                                 // It has node's input, output, etc..
+    const auto &tensors = _reader.tensors();     // tensor is operator's input or output node.
+    auto tensors_ptr = _reader.tensors_ptr();
     assert(tensors_ptr != nullptr);
-    auto circle_metadata = std::make_unique<luci::CircleImportMetadata>(reader);
 
-    auto nodefinder = std::make_unique<luci::IndexNodeFinder>();
+    auto nodefinder = std::make_unique<luci::IndexNodeFinder>(); // node find helper
     auto tensoroutputs = std::make_unique<luci::IndexTensorOutputs>();
 
-    luci::GraphBuilderContext gb_context(graph.get(), &reader, nodefinder.get(), tensoroutputs.get());
+    luci::GraphBuilderContext gb_context(graph.get(), &_reader, nodefinder.get(),
+                                         tensoroutputs.get()); // graph build helper.
 
-    for(auto iter = id_name_selected_nodes.begin(); iter != id_name_selected_nodes.end(); iter++)
+    // print selected operator's detail.
+    std::cout << "Subgraph Name: " << _reader.name() << std::endl;
+    for (auto iter = id_name_selected_nodes.begin(); iter != id_name_selected_nodes.end(); iter++)
     {
-      selected_operators.push_back(opers[iter->first].get());
-
-      std::cout << "============== Type: " << tense[opers[iter->first]->outputs[0]]->type << " ==============" << std::endl;
+      selected_operators.push_back(operators[iter->first].get()); // put selected nodes in vector.
+      std::cout << "============== Type: " << tensors[operators[iter->first]->outputs[0]]->type
+                << " ==============" << std::endl;
       std::cout << "    <INPUT>" << std::endl;
-      for(auto node : opers[iter->first].get()->inputs)
-        std::cout<<"operator["<< iter->first << "] id: " << node <<" " << "input: " << tense[node]->name << std::endl;
+      for (auto node : operators[iter->first].get()->inputs)
+        std::cout << "operator[" << iter->first << "] id: " << node << " "
+                  << "input: " << tensors[node]->name << std::endl;
       std::cout << "    <OUTPUT>" << std::endl;
-      for(auto node : opers[iter->first].get()->outputs)
-        std::cout<<"operator["<< iter->first << "] id: " << node <<" " << "output: " << tense[node]->name << std::endl;
-      std::cout<<std::endl;
+      for (auto node : operators[iter->first].get()->outputs)
+        std::cout << "operator[" << iter->first << "] id: " << node << " "
+                  << "output: " << tensors[node]->name << std::endl;
+      std::cout << std::endl;
+    }
+
+    // find the node that has no preceding node
+    input_nodes.push_back(selected_operators[0]); // first node must not have preceding node.
+    for (uint32_t node1 = 1; node1 < selected_operators.size(); ++node1)
+    {
+      bool input_connected = false;
+
+      for (uint32_t node2 = 0; node2 < selected_operators.size(); ++node2)
+      {
+        if (node1 == node2)
+          continue;
+        // find input
+        for (auto input : selected_operators[node1]->inputs)
+        {
+          for (auto output : selected_operators[node2]->outputs)
+          {
+            if (input == output)
+              input_connected = true;
+          }
+        }
+      }
+
+      if (!input_connected)
+        input_nodes.push_back(selected_operators[node1]);
+    }
+
+    // find the node that has no trailing node
+    output_nodes.push_back(
+      selected_operators[selected_operators.size() - 1]); // last node must not have trailing node
+    for (uint32_t node1 = 0; node1 < selected_operators.size() - 1; ++node1)
+    {
+      bool output_connected = false;
+
+      for (uint32_t node2 = 0; node2 < selected_operators.size(); ++node2)
+      {
+        if (node1 == node2)
+          continue;
+        // find input
+        for (auto output : selected_operators[node1]->outputs)
+        {
+          for (auto input : selected_operators[node2]->inputs)
+          {
+            if (input == output)
+              output_connected = true;
+          }
+        }
+      }
+
+      if (!output_connected)
+        output_nodes.push_back(selected_operators[node1]);
     }
 
     // build a cache to identify if a tensor is output of an operator
     // if this is set, we should not create a CircleConst for this tensor
-    for (uint32_t i = 0; i < opers.size(); ++i)
+    for (uint32_t i = 0; i < operators.size(); ++i)
     {
-      const circle::OperatorT &op = *opers[i];
+      const circle::OperatorT &op = *operators[i];
       const auto &outputs = op.outputs;
 
       for (uint32_t j = 0; j < outputs.size(); ++j)
@@ -272,16 +322,20 @@ std::unique_ptr<luci::Module> OpSelector::select_nodes(const circle::Model *circ
         tensoroutputs->enroll(tidx);
       }
     }
-    
-    //for (const auto input : selected_operators[0]->inputs)
-    for (int a=0; a<1; a++)
+
+    // graph inputs; there are no input nodes in TFlite but just Tensors
+    // creating virtual input nodes will make possible to connect nodes that uses them
+    // all attributes of tensor should be copied to CircleInput node
+    for (auto node : input_nodes)
     {
-      int input=selected_operators[0]->inputs[0];
+      int input = node->inputs[0];
       auto input_node = graph->nodes()->create<luci::CircleInput>();
+
       assert(input_node != nullptr);
-      const circle::TensorT &tensor = *tense[input];
+      const circle::TensorT &tensor = *tensors[input];
 
       luci::copy_tensor_attributes(tensor, input_node);
+
       if (tensors_ptr->Get(input)->shape() == nullptr)
         input_node->shape_status(luci::ShapeStatus::NOSHAPE);
       else
@@ -303,7 +357,7 @@ std::unique_ptr<luci::Module> OpSelector::select_nodes(const circle::Model *circ
       graph_input->dtype(input_node->dtype());
 
       assert(tensor.shape_signature.size() == 0 ||
-            tensor.shape_signature.size() == tensor.shape.size());
+             tensor.shape_signature.size() == tensor.shape.size());
 
       // Shape of GraphInput
       auto input_shape = std::make_unique<loco::TensorShape>();
@@ -319,122 +373,126 @@ std::unique_ptr<luci::Module> OpSelector::select_nodes(const circle::Model *circ
       graph_input->shape(std::move(input_shape));
     }
     // Create CircleConst nodes for constant tensors.
-    for (uint32_t i = 0; i < tense.size(); ++i)
+    for (uint32_t i = 0; i < tensors.size(); ++i)
     {
       luci::CircleConst *const_node = luci::create_circleconst(&gb_context, i);
       if (const_node != nullptr)
         nodefinder->enroll(i, const_node);
     }
 
-    
     // Import the operators.
     // Note that operators in model are stored in execution order. This means that when importing
     // an operator, its input operators have already been imported. We exploit this fact to set up
     // node's inputs right after creating the node.
-    auto origin_table = circle_metadata->origin_table();
-    for (uint32_t i = 0; i < opers.size(); ++i)
+    for (uint32_t i = 0; i < operators.size(); ++i)
     {
-      const circle::OperatorT &op = *opers[i];
-      circle::BuiltinOperator builtincode = reader.builtin_code(op);
+      const circle::OperatorT &op = *operators[i];
+      circle::BuiltinOperator builtincode = _reader.builtin_code(op);
 
       if (const auto *builder = source_ptr->lookup(builtincode))
       {
-        luci::GraphBuilder::ValidateArgs args(op, reader);
+        luci::GraphBuilder::ValidateArgs args(op, _reader);
         if (!builder->validate(args))
         {
-          throw oops::UserExn("Invalid operator", reader.opcode_name(op));
+          throw oops::UserExn("Invalid operator", _reader.opcode_name(op));
         }
 
         auto built_op = builder->build(op, &gb_context);
         luci::set_node_id(built_op, i);
-        if (origin_table.find(i) != origin_table.end())
-          add_origin(built_op, origin_table.at(i));
-        else
-          add_origin(built_op, luci::single_origin(i, built_op->name()));
+
+        add_origin(built_op, luci::single_origin(i, built_op->name()));
       }
       else
       {
-        throw oops::UserExn("Not supported", reader.opcode_name(op));
+        throw oops::UserExn("Not supported", _reader.opcode_name(op));
       }
     }
 
     // graph outputs
-    for (auto output : selected_operators[selected_operators.size()-1]->outputs)
+    for (auto node : output_nodes)
     {
-      const circle::TensorT &tensor = *tense[output];
-
-      auto output_node = graph->nodes()->create<luci::CircleOutput>();
-      assert(output_node != nullptr);
-      auto output_from = nodefinder->node(output);
-      if (output_from != nullptr)
-        output_node->from(output_from);
-      else
+      for (auto output : node->outputs)
       {
-        // NOTE loco::Graph requires all input node(s) to a node should exist.
-        //      Here, CircleOutput needs an input node.
-        //      We add a dummy node to make it happy.
-        auto output_dummy = graph->nodes()->create<luci::CircleOutputDummy>();
-        assert(output_dummy != nullptr);
-        output_node->from(output_dummy);
+        const circle::TensorT &tensor = *tensors[output];
 
-        luci::copy_tensor_attributes(tensor, output_dummy);
-        if (tensors_ptr->Get(output)->shape() == nullptr)
-          output_dummy->shape_status(luci::ShapeStatus::NOSHAPE);
+        auto output_node = graph->nodes()->create<luci::CircleOutput>();
+        assert(output_node != nullptr);
+        auto output_from = nodefinder->node(output);
+        if (output_from != nullptr)
+          output_node->from(output_from);
         else
-          output_dummy->shape_status(luci::ShapeStatus::VALID);
+        {
+          // NOTE loco::Graph requires all input node(s) to a node should exist.
+          //      Here, CircleOutput needs an input node.
+          //      We add a dummy node to make it happy.
+          auto output_dummy = graph->nodes()->create<luci::CircleOutputDummy>();
+          assert(output_dummy != nullptr);
+          output_node->from(output_dummy);
+
+          luci::copy_tensor_attributes(tensor, output_dummy);
+          if (tensors_ptr->Get(output)->shape() == nullptr)
+            output_dummy->shape_status(luci::ShapeStatus::NOSHAPE);
+          else
+            output_dummy->shape_status(luci::ShapeStatus::VALID);
+        }
+
+        // set the graph output name and node object
+        auto graph_output = graph->outputs()->create();
+        std::string tname = luci::tensor_name(tensor);
+        assert(tname.length() > 0);
+        graph_output->name(tname);
+
+        luci::copy_tensor_attributes(tensor, output_node);
+
+        // Set GraphInputOutputIndex for graph
+        output_node->index(graph_output->index());
+
+        assert(tensor.shape_signature.size() == 0 ||
+               tensor.shape_signature.size() == tensor.shape.size());
+
+        // Shape of Output
+        auto output_shape = std::make_unique<loco::TensorShape>();
+        const std::vector<int32_t> &output_dims = tensor.shape; // in NHWC
+        output_shape->rank(output_dims.size());
+        for (uint32_t r = 0; r < output_dims.size(); ++r)
+        {
+          if (tensor.shape_signature.size() > 0 && tensor.shape_signature.at(r) == -1)
+            output_shape->dim(r).unset();
+          else
+            output_shape->dim(r).set(output_dims[r]);
+        }
+        graph_output->shape(std::move(output_shape));
+
+        // Data type
+        auto dtype = luci::luci_datatype(tensor.type);
+        graph_output->dtype(dtype);
       }
-
-      // set the graph output name and node object
-      auto graph_output = graph->outputs()->create();
-      std::string tname = luci::tensor_name(tensor);
-      assert(tname.length() > 0);
-      graph_output->name(tname);
-
-      luci::copy_tensor_attributes(tensor, output_node);
-
-      // Set GraphInputOutputIndex for graph
-      output_node->index(graph_output->index());
-
-      assert(tensor.shape_signature.size() == 0 ||
-            tensor.shape_signature.size() == tensor.shape.size());
-
-      // Shape of Output
-      auto output_shape = std::make_unique<loco::TensorShape>();
-      const std::vector<int32_t> &output_dims = tensor.shape; // in NHWC
-      output_shape->rank(output_dims.size());
-      for (uint32_t r = 0; r < output_dims.size(); ++r)
-      {
-        if (tensor.shape_signature.size() > 0 && tensor.shape_signature.at(r) == -1)
-          output_shape->dim(r).unset();
-        else
-          output_shape->dim(r).set(output_dims[r]);
-      }
-      graph_output->shape(std::move(output_shape));
-
-      // Data type
-      auto dtype = luci::luci_datatype(tensor.type);
-      graph_output->dtype(dtype);
     }
 
-    module->add(std::move(graph));
+    module->add(std::move(graph)); // add graph in module
   }
-  for (uint32_t g = 1; g < reader.num_subgraph(); ++g)
+  for (uint32_t g = 1; g < _reader.num_subgraph(); ++g)
   {
     auto graph = loco::make_graph();
-    
-    if (!reader.select_subgraph(g))
+
+    if (!_reader.select_subgraph(g))
       return nullptr;
 
-    graph->name(reader.name());
+    graph->name(_reader.name());
 
     // Convert circle::Model to loco::Graph
-    convert_graph(*source_ptr, reader, graph.get());
+    convert_graph(*source_ptr, _reader, graph.get());
 
     module->add(std::move(graph));
   }
 
-  luci::post_import_graph(module.get(), reader);
-
+  // luci::post_import_graph(module.get(), _reader); // No this function, can't select if and while
+  // node.
+  // err msg:
+  // opselector:
+  // /home/dongyoon/SOSCON/ONE/compiler/luci/service/src/CircleShapeInferenceRule.cpp:1990:
+  // loco::NodeShape {anonymous}::infer_while_out(const luci::CircleWhileOut*): Assertion
+  // `cond_graph != nullptr' failed
   return module;
 }
 

--- a/compiler/circle-opselector/pass/OpSelector.cpp
+++ b/compiler/circle-opselector/pass/OpSelector.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "OpSelector.h"
-#include "luci/../../src/CircleImportMetadata.h"
-#include "luci/../../src/PostImport.h"
+// #include "luci/../../src/CircleImportMetadata.h"
+// #include "luci/../../src/PostImport.h"
 
 #include "luci/Service/ChangeOutputs.h"
 

--- a/compiler/circle-opselector/pass/OpSelector.h
+++ b/compiler/circle-opselector/pass/OpSelector.h
@@ -27,12 +27,17 @@ namespace opselector
 class OpSelector
 {
 public:
+  OpSelector() = default;
+  OpSelector(const circle::Model *model) : _src_model(model) { assert(_reader.parse(_src_model)); }
   ~OpSelector() = default;
 
 public:
   std::unique_ptr<luci::Module>
-  select_nodes(const circle::Model *circle_model,
-               std::map<uint32_t, std::string> &id_name_selected_nodes);
+  select_nodes(std::map<uint32_t, std::string> &id_name_selected_nodes);
+
+private:
+  luci::CircleReader _reader;
+  const circle::Model *_src_model;
 };
 
 } // namespace opselector


### PR DESCRIPTION
Updated some features of node selection.

It works well, but still have some problems.

1. It still needs private header `luci/../../src/PostImport.h`.
> It works fine without this, but when I select a `while` or `if` node I can't get it to run.
2. When I select a `while` or `if` node as input node(it means there is no preceding node in front of these node), it didn't work.

ONE-DCO-1.0-Signed-off-by: dongyooncho <dycho96@gmail.com>